### PR TITLE
Allow for Empty String inline keyboard queries.

### DIFF
--- a/lib/methods.js
+++ b/lib/methods.js
@@ -44,7 +44,7 @@ const methods = {
   inlineButton(text, opt={}) {
     const markup = { text };
     if (opt.url) markup.url = opt.url;
-    if (opt.inline) markup.switch_inline_query = opt.inline;
+    if (opt.inline || opt.inline === '') markup.switch_inline_query = opt.inline;
     if (opt.callback) markup.callback_data = opt.callback;
     return markup;
   },


### PR DESCRIPTION
Allows for inline keyboard inline queries to be created blank, showing the default inline bot message when shared to another conversation.