### PR TITLE
Fix missing port error

### DIFF
--- a/lib/webhook.js
+++ b/lib/webhook.js
@@ -21,8 +21,9 @@ module.exports = (bot, opt) => {
 
   // Check port
   if (!PORTS.includes(port)) {
+    let error = `[bot.error.webhook] allowed ports: ${ PORTS.join(', ') }`;
     this.event('error', { error });
-    console.error(`[bot.error.webhook] allowed ports: ${ PORTS.join(', ') }`);
+    console.error(error);
     return;
   }
 


### PR DESCRIPTION
Previously, `this.event('error', { error });` throw exception because of missing error variable.