### PR TITLE
Remove `event` usage in webhook

### DIFF
--- a/lib/webhook.js
+++ b/lib/webhook.js
@@ -21,9 +21,7 @@ module.exports = (bot, opt) => {
 
   // Check port
   if (!PORTS.includes(port)) {
-    let error = `[bot.error.webhook] allowed ports: ${ PORTS.join(', ') }`;
-    this.event('error', { error });
-    console.error(error);
+    console.error(`[bot.warning.webhook] allowed ports: ${ PORTS.join(', ') }`);
     return;
   }
 

--- a/lib/webhook.js
+++ b/lib/webhook.js
@@ -6,9 +6,6 @@ const
   http = require('http'),
   https = require('https');
 
-// Allowed ports
-const PORTS = [443, 80, 88, 8443];
-
 module.exports = (bot, opt) => {
 
   const token = '/' + bot.token;
@@ -18,12 +15,6 @@ module.exports = (bot, opt) => {
     port = opt.port || 443,
     key = opt.key && fs.readFileSync(opt.key),
     cert = opt.cert && fs.readFileSync(opt.cert);
-
-  // Check port
-  if (!PORTS.includes(port)) {
-    console.error(`[bot.warning.webhook] allowed ports: ${ PORTS.join(', ') }`);
-    return;
-  }
 
   // Create server
   const server = key && cert ?


### PR DESCRIPTION
`event` is not defined in current context, and I thought that telegram bot could be hidden behind proxy with non-default port(like in "Heroku") so there is no reason to throw an error in this case.