### PR TITLE
Fix webhook listener

### DIFF
--- a/lib/webhook.js
+++ b/lib/webhook.js
@@ -32,10 +32,10 @@ module.exports = (bot, opt) => {
       var json = '';
       req.on('data', data => json += data);
       req.on('end', x => {
+        res.end();
         bot.receiveUpdates([JSON.parse(json)], true);
       });
     }
-    res.end();
   }
 
 };


### PR DESCRIPTION
The request is ended before whole data received, this usually occurs when running a bot on Heroku, see [support ticket](https://help.heroku.com/tickets/367399).