### PR TITLE
added link to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,3 +371,4 @@ Use this method to get current webhook status.
 ## Documentation
 
 Read [wiki on GitHub](https://github.com/kosmodrey/telebot/wiki).
+Test on [RapidAPI](https://rapidapi.com/package/TelegramBot/functions?utm_source=TelegramGitHub&utm_medium=button)


### PR DESCRIPTION
I've added a link in your README to Telegram's functions page in RapidAPI. I've done this for a few Telegram SDKs to help those who are reading the READMEs, understand and test the API before use.