### PR TITLE
Added parse parameter for sendMessage method

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Use this method to send `answerList` to an inline query.
 
 Use this method to get basic info about a file and prepare it for downloading.
 
-##### `sendMessage(<chat_id>, <text>, {reply, markup, notify, preview})`
+##### `sendMessage(<chat_id>, <text>, {parse, reply, markup, notify, preview})`
 
 Use this method to send text messages.
 


### PR DESCRIPTION
parse parameter was missing from the documentation, took me a long time to find out how to use markdowns.