### PR TITLE
Fix variation declaration of "opt" in modules/flooder

### DIFF
--- a/modules/flooder.js
+++ b/modules/flooder.js
@@ -20,7 +20,7 @@ const userList = {};
 module.exports = (bot, cfg) => {
 
   // Load config data
-  let opt = cfg.flood || {};
+  let opt = cfg.flooder || {};
   let interval = Number(opt.interval) || 1;
   let text = opt.message === undefined ?
     'Too many messages from you. Please, try later...' :
@@ -49,9 +49,9 @@ module.exports = (bot, cfg) => {
     } else {
       userList[id] = { lastTime: now };
     }
-  
+
     return data;
-  
+
   });
 
 };


### PR DESCRIPTION
Fix variation declaration of "opt" in modules/flooder from "cfg.flood" to "cfg.flooder"
because the parameter for module use accepts "flooder" not "flood".